### PR TITLE
Space after if statement fixing Gulp build error

### DIFF
--- a/src/React/Scripts/redux/modules/people.js
+++ b/src/React/Scripts/redux/modules/people.js
@@ -23,7 +23,7 @@ export default function reducer(state = {}, action = {}) {
         error: 'An error occured loading people. This error is thrown randomly for demo purposes.'
       };
     default:
-      if(!state) return {}; // we want to always have at least an empty object
+      if (!state) return {}; // we want to always have at least an empty object
       return state;
   }
 }


### PR DESCRIPTION
There was no space after the if keyword on line 26, which was causing an error during the series of build events kicked off by running gulp.
