### PR TITLE
Webpack Dev Config: Fixed all paths to work correctly on any platform

### DIFF
--- a/src/React/Scripts/webpack/dev.config.js
+++ b/src/React/Scripts/webpack/dev.config.js
@@ -2,14 +2,14 @@ var fs = require('fs');
 var babelrc = JSON.parse(fs.readFileSync('./.babelrc'));
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var extractCSS = new ExtractTextPlugin('styles.css');
-var webpack = require("webpack");
+var webpack = require('webpack');
 var path = require('path');
 
 module.exports = {
-  server : {
+  server: {
     entry: {
-      'server': [
-        './Scripts/server.js'
+      server: [
+         path.resolve(__dirname, '..', '..', 'Scripts', 'server.js')
       ]
     },
     resolve: {
@@ -18,13 +18,13 @@ module.exports = {
         'node_modules'
       ],
       alias: {
-        "superagent": path.resolve(__dirname + "/../utils/superagent-server.js"),
-        "promise-window": path.resolve(__dirname + "/../utils/promise-window-server.js")
+        'superagent': path.resolve(__dirname, '..', 'utils', 'superagent-server.js'),
+        'promise-window': path.resolve(__dirname, '..', 'utils', 'promise-window-server.js')
       }
     },
     module: {
       loaders: [
-        { test: /\.jsx?$/, exclude: /node_modules/, loaders: ['babel?' + JSON.stringify(babelrc), 'eslint']},
+        { test: /\.jsx?$/, exclude: /node_modules/, loaders: ['babel?' + JSON.stringify(babelrc), 'eslint'] },
         { test: /\.css$/, loader: 'css/locals?module' },
         { test: /\.scss$/, loader: 'css/locals?module!sass' },
         { test: /\.(woff2?|ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: 'file' },
@@ -34,7 +34,7 @@ module.exports = {
     output: {
       filename: '[name].generated.js',
       libraryTarget: 'this',
-      path: path.resolve(__dirname + "../../../wwwroot/pack"),
+      path: path.resolve(__dirname, '..', '..', 'wwwroot', 'pack'),
       publicPath: '/pack/'
     },
     plugins: [
@@ -46,9 +46,9 @@ module.exports = {
   },
   client: {
     entry: {
-      'client': [
+      client: [
         'bootstrap-loader',
-        './Scripts/client.js'
+        path.resolve(__dirname, '..', '..', 'Scripts', 'client.js')
       ]
     },
     resolve: {
@@ -59,7 +59,7 @@ module.exports = {
     },
     module: {
       loaders: [
-        { test: /\.jsx?$/, exclude: /node_modules/, loaders: ['babel?' + JSON.stringify(babelrc), 'eslint']},
+        { test: /\.jsx?$/, exclude: /node_modules/, loaders: ['babel?' + JSON.stringify(babelrc), 'eslint'] },
         { test: /\.css$/, loader: extractCSS.extract('style', 'css?modules') },
         { test: /\.scss$/, loader: extractCSS.extract('style', 'css?modules!sass') },
         { test: /\.(woff2?|ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: 'file' },
@@ -69,7 +69,7 @@ module.exports = {
     output: {
       filename: '[name].generated.js',
       libraryTarget: 'this',
-      path: path.resolve(__dirname + "../../../wwwroot/pack"),
+      path: path.resolve(__dirname, '..', '..', 'wwwroot', 'pack'),
       publicPath: '/pack/'
     },
     plugins: [
@@ -81,4 +81,4 @@ module.exports = {
     ],
     devtool: 'source-map'
   }
-}
+};


### PR DESCRIPTION
Using path.resolve in this way allows the right path to be generated on any platform... It figures out "/" and "\" on its own and creates the right path.

Other than that, there are just minor style fixes put in for consistency because eslint was complaining. I fixed the prod config file as well. I'll make a separate PR for that.
